### PR TITLE
fix: print out error chain

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -176,11 +176,23 @@ async fn run() -> Result<()> {
                         p.inc(1);
                     }
                 }
-                Err(e) => print_with_target(
-                    progress.as_ref(),
-                    format!("Error listing objects: {e}").as_str(),
-                    OutputTarget::Stderr,
-                ),
+                Err(e) => {
+                    print_with_target(
+                        progress.as_ref(),
+                        format!("Error listing objects: {e}").as_str(),
+                        OutputTarget::Stderr,
+                    );
+                    // Print the error source chain for more detail
+                    let mut source = e.source();
+                    while let Some(s) = source {
+                        print_with_target(
+                            progress.as_ref(),
+                            format!("  caused by: {s}").as_str(),
+                            OutputTarget::Stderr,
+                        );
+                        source = s.source();
+                    }
+                }
             }
         }
     })


### PR DESCRIPTION
The error stream err is vague and doesn't help the user debug at all, try to provide more detail. 